### PR TITLE
feat: realtime token authorization for server-side transcribe/translate (Vibe Kanban)

### DIFF
--- a/live_server/app/database.py
+++ b/live_server/app/database.py
@@ -8,3 +8,4 @@ db = client[MONGODB_SETTINGS.get('db', 'opentranslive-db')]
 
 rooms_collection = db['room']
 transcription_store_collection = db['transcription_store']
+realtime_tokens_collection = db['realtime_tokens']

--- a/live_server/app/static/js/realtime.js
+++ b/live_server/app/static/js/realtime.js
@@ -8,7 +8,7 @@ socket.on('connect', function () {
   console.log('WebSocket connection opened');
 
   // Join the session room
-  socket.emit('join_session', { session_id: sessionId, secret_key: user_secret_key });
+  socket.emit('join_session', { session_id: sessionId, secret_key: user_secret_key, realtime_token: user_realtime_token });
 });
 
 socket.on('disconnect', function () {
@@ -66,6 +66,7 @@ async function startSession() {
 
       socket.emit('audio_buffer_append', {
         secret_key: user_secret_key,
+        realtime_token: user_realtime_token,
         audio: base64Audio
       });
 

--- a/live_server/app/templates/panel.html
+++ b/live_server/app/templates/panel.html
@@ -132,6 +132,7 @@
   const sid = "{{ sid }}"
   const sessionId = "{{ sid }}"
   const user_secret_key = "{{ user_secret_key }}"
+  const user_realtime_token = "{{ user_realtime_token }}"
 
   // ── Mic toggle ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What Changed

Added a token-based authorization layer to protect the server-side ElevenLabs transcription and OpenAI translation APIs from unauthorized use via the browser Panel.

## Why

Previously, anyone who obtained a session `secret_key` could trigger the `realtime_connect` and `audio_buffer_append` WebSocket events from the Panel, causing ElevenLabs and OpenAI API calls at the server owner's expense. The `realtime_connect` event had **no authentication check at all**.

## Implementation

### Token Storage & Management
- Tokens are stored in a new MongoDB collection `realtime_tokens`
- Three Admin API endpoints (protected by `Authorization: Bearer {SECRET_KEY}`) allow dynamic token management **without restarting the server**:
  - `POST /api/tokens` — create a token (with optional `label`)
  - `GET /api/tokens` — list all tokens
  - `DELETE /api/tokens/{token}` — revoke a token

### Authorization Logic (`is_realtime_authorized`)
Three-tier check — passes if **any** of:
1. Socket connected with the global `SECRET_KEY` (admin, e.g. `transcribe_client` / `realtime_client`) → always allowed
2. No tokens exist in DB (empty collection) → allow everyone (backward compatible)
3. A valid `realtime_token` is found in the event data or socket session

### Socket.IO Changes
- `connect` handler now distinguishes `admin: True` vs `admin: False` in socket session
- `join_session` accepts and stores `realtime_token` in socket session (so it only needs to be sent once per connection)
- `realtime_connect` and `audio_buffer_append` both check `is_realtime_authorized` before proceeding

### Panel Changes
- `/panel/{sid}` route accepts `?realtime_token=...` query param, stored in the Starlette cookie session
- `panel.html` exposes `user_realtime_token` as a JS variable
- `realtime.js` includes `realtime_token` in `join_session` and `audio_buffer_append` emissions

## Files Changed

| File | Change |
|------|--------|
| `live_server/app/database.py` | Add `realtime_tokens_collection` |
| `live_server/app/__init__.py` | Authorization helper, Admin API, updated event handlers and panel route |
| `live_server/app/templates/panel.html` | Add `user_realtime_token` JS variable |
| `live_server/app/static/js/realtime.js` | Pass `realtime_token` in WebSocket events |

## Backward Compatibility

If the `realtime_tokens` collection is empty (default), behavior is identical to before — no restrictions. Restrictions only activate once the admin creates the first token. External clients (`transcribe_client`, `realtime_client`) using the global `SECRET_KEY` are unaffected.

## Usage

```bash
# Create a token for a trusted user
curl -X POST https://your-server/api/tokens \
  -H "Authorization: Bearer YOUR_SECRET_KEY" \
  -H "Content-Type: application/json" \
  -d '{"label": "Sean"}'

# Share the Panel URL with the token
# /panel/{sid}?secret_key=xxx&realtime_token=yyy

# Revoke a token
curl -X DELETE https://your-server/api/tokens/THE_TOKEN \
  -H "Authorization: Bearer YOUR_SECRET_KEY"
```

---

This PR was written using [Vibe Kanban](https://vibekanban.com)