### PR TITLE
Remove secrets from URLs and implement first-user-becomes-admin session control (Vibe Kanban)

### DIFF
--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -503,6 +503,29 @@ async def disconnect(socket_id):
     """Handle client disconnection"""
     print(f"Client disconnected: {socket_id}")
 
+    # Get session data to check if this was an admin
+    session = await sio.get_session(socket_id)
+    user_uid = session.get('user_uid')
+    session_id = session.get('session_id')
+
+    if user_uid and session_id:
+        # Check if this user was the admin for this session
+        room = await rooms_collection.find_one({"sid": session_id})
+        if room and room.get("admin_uid") == user_uid:
+            # Release admin lock immediately on disconnect
+            await rooms_collection.update_one(
+                {"sid": session_id},
+                {
+                    "$set": {
+                        "secret_key": None,
+                        "admin_uid": None,
+                        "admin_last_heartbeat": None,
+                        "updated_at": datetime.now(timezone.utc)
+                    }
+                }
+            )
+            print(f"Admin lock released for session {session_id} on disconnect")
+
 async def _process_transcription_update(session_id, sync_data):
     """Internal helper to process transcription updates (cache, DB, and broadcast)"""
     # Fetch cached transcription data (Redis or DB)
@@ -591,6 +614,7 @@ async def join_session(socket_id, data):
     session_id = data.get('session_id')
     secret_key = data.get('secret_key')
     realtime_token = data.get('realtime_token')
+    user_uid = data.get('user_uid')
 
     session = await sio.get_session(socket_id)
 
@@ -600,8 +624,10 @@ async def join_session(socket_id, data):
         if room:
             session['secret_key'] = secret_key
             session['verified'] = True
+            session['user_uid'] = user_uid or room.get('admin_uid')
+            session['session_id'] = session_id
             await sio.save_session(socket_id, session)
-            print(f"Client verified: {session_id}")
+            print(f"Client verified: {session_id}, user_uid: {session.get('user_uid')}")
 
     if realtime_token:
         session['realtime_token'] = realtime_token

--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -3,7 +3,7 @@
 # Licensed under the GNU AGPL v3.0
 # See LICENSE for details.
 
-from fastapi import FastAPI, Request, Form, HTTPException, Query
+from fastapi import FastAPI, Request, Form, HTTPException
 from fastapi.responses import HTMLResponse, Response, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
@@ -364,16 +364,12 @@ async def create_session(request: Request, sid: str = Form(...)):
         "created_at": datetime.now(timezone.utc),
         "extra": {}
     })
-    
+
     request.session["secret_key"] = session_secret_key
-    return RedirectResponse(url=f"/panel/{sid}?secret_key={session_secret_key}", status_code=303)
+    return RedirectResponse(url=f"/panel/{sid}", status_code=303)
 
 @app.get("/panel/{sid}", response_class=HTMLResponse)
-async def panel(request: Request, sid: str, secret_key: str | None = Query(default=None), realtime_token: str | None = Query(default=None)):
-    if secret_key:
-        request.session["secret_key"] = secret_key
-    if realtime_token:
-        request.session["realtime_token"] = realtime_token
+async def panel(request: Request, sid: str):
     user_secret_key = request.session.get("secret_key")
     user_realtime_token = request.session.get("realtime_token", "")
     if not user_secret_key:

--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -337,8 +337,6 @@ async def rt(request: Request, id: str):
   
 @app.post("/create-session", response_class=HTMLResponse)
 async def create_session(request: Request, sid: str = Form(...)):
-    session_secret_key = str(uuid.uuid4())
-    
     # Check if room already exists using Motor
     existing_room = await rooms_collection.find_one({"sid": sid})
     if existing_room:
@@ -356,33 +354,90 @@ async def create_session(request: Request, sid: str = Form(...)):
         </body>
         </html>
         """)
-    
-    # Create new room
+
+    # Create new room without secret_key (will be set by first user)
     await rooms_collection.insert_one({
         "sid": sid,
-        "secret_key": session_secret_key,
+        "secret_key": None,
+        "admin_uid": None,
         "created_at": datetime.now(timezone.utc),
         "extra": {}
     })
 
-    request.session["secret_key"] = session_secret_key
     return RedirectResponse(url=f"/panel/{sid}", status_code=303)
 
 @app.get("/panel/{sid}", response_class=HTMLResponse)
 async def panel(request: Request, sid: str):
-    user_secret_key = request.session.get("secret_key")
-    user_realtime_token = request.session.get("realtime_token", "")
-    if not user_secret_key:
-        raise HTTPException(status_code=401, detail="Unauthorized")
+    # Ensure user has a UID
+    user_uid = request.session.get("user_uid")
+    if not user_uid:
+        user_uid = str(uuid.uuid4())
+        request.session["user_uid"] = user_uid
 
-    # Verify room exists with matching secret key using Motor
-    room = await rooms_collection.find_one({"sid": sid, "secret_key": user_secret_key})
+    # Find the room
+    room = await rooms_collection.find_one({"sid": sid})
     if not room:
-        raise HTTPException(status_code=401, detail="Unauthorized")
+        raise HTTPException(status_code=404, detail="Session not found")
 
+    # Check if there's already an admin
+    if room.get("admin_uid") and room.get("secret_key"):
+        # Admin exists - check if current user is the admin
+        user_secret_key = request.session.get("secret_key")
+        if user_secret_key != room["secret_key"] or user_uid != room["admin_uid"]:
+            raise HTTPException(status_code=403, detail="Session admin is already connected")
+        # User is the existing admin
+    else:
+        # No admin yet - make this user the admin
+        session_secret_key = str(uuid.uuid4())
+        await rooms_collection.update_one(
+            {"sid": sid},
+            {
+                "$set": {
+                    "secret_key": session_secret_key,
+                    "admin_uid": user_uid,
+                    "updated_at": datetime.now(timezone.utc)
+                }
+            }
+        )
+        request.session["secret_key"] = session_secret_key
+        user_secret_key = session_secret_key
+
+    user_realtime_token = request.session.get("realtime_token", "")
     is_realtime_enabled = await is_realtime_authorized(request.session)
 
-    return templates.TemplateResponse("panel.html", {"request": request, "sid": sid, "user_secret_key": user_secret_key, "user_realtime_token": user_realtime_token, "is_realtime_enabled": is_realtime_enabled})
+    return templates.TemplateResponse("panel.html", {"request": request, "sid": sid, "user_uid": user_uid, "user_secret_key": user_secret_key, "user_realtime_token": user_realtime_token, "is_realtime_enabled": is_realtime_enabled})
+
+@app.post("/release-admin/{sid}")
+async def release_admin(request: Request, sid: str):
+    """Release admin lock when admin leaves"""
+    user_uid = request.session.get("user_uid")
+    user_secret_key = request.session.get("secret_key")
+
+    if not user_uid or not user_secret_key:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    # Verify this user is the current admin
+    room = await rooms_collection.find_one({"sid": sid})
+    if not room:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    if room.get("admin_uid") == user_uid and room.get("secret_key") == user_secret_key:
+        # Clear admin lock
+        await rooms_collection.update_one(
+            {"sid": sid},
+            {
+                "$set": {
+                    "secret_key": None,
+                    "admin_uid": None,
+                    "updated_at": datetime.now(timezone.utc)
+                }
+            }
+        )
+        # Clear session
+        request.session.pop("secret_key", None)
+        return {"status": "released"}
+
+    return {"status": "not_admin"}
 
 # Socket.IO Event Handlers
 @sio.event

--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -360,6 +360,7 @@ async def create_session(request: Request, sid: str = Form(...)):
         "sid": sid,
         "secret_key": None,
         "admin_uid": None,
+        "admin_last_heartbeat": None,
         "created_at": datetime.now(timezone.utc),
         "extra": {}
     })
@@ -379,15 +380,50 @@ async def panel(request: Request, sid: str):
     if not room:
         raise HTTPException(status_code=404, detail="Session not found")
 
+    # Admin timeout: 30 seconds
+    ADMIN_TIMEOUT = 30
+    now = datetime.now(timezone.utc)
+
     # Check if there's already an admin
     if room.get("admin_uid") and room.get("secret_key"):
-        # Admin exists - check if current user is the admin
-        user_secret_key = request.session.get("secret_key")
-        if user_secret_key != room["secret_key"] or user_uid != room["admin_uid"]:
-            raise HTTPException(status_code=403, detail="Session admin is already connected")
-        # User is the existing admin
-    else:
-        # No admin yet - make this user the admin
+        # Check if admin heartbeat is stale
+        last_heartbeat = room.get("admin_last_heartbeat")
+        admin_expired = False
+        if last_heartbeat:
+            elapsed = (now - last_heartbeat).total_seconds()
+            admin_expired = elapsed > ADMIN_TIMEOUT
+        else:
+            # No heartbeat recorded, consider expired
+            admin_expired = True
+
+        if admin_expired:
+            # Admin session expired, clear it
+            await rooms_collection.update_one(
+                {"sid": sid},
+                {
+                    "$set": {
+                        "secret_key": None,
+                        "admin_uid": None,
+                        "admin_last_heartbeat": None,
+                        "updated_at": now
+                    }
+                }
+            )
+            # Re-fetch room to get clean state
+            room = await rooms_collection.find_one({"sid": sid})
+        else:
+            # Admin exists and is active - check if current user is the admin
+            user_secret_key = request.session.get("secret_key")
+            if user_secret_key != room["secret_key"] or user_uid != room["admin_uid"]:
+                raise HTTPException(status_code=403, detail="Session admin is already connected")
+            # User is the existing admin - update heartbeat
+            await rooms_collection.update_one(
+                {"sid": sid},
+                {"$set": {"admin_last_heartbeat": now, "updated_at": now}}
+            )
+
+    # If no admin or admin was cleared, make this user the admin
+    if not room.get("admin_uid") or not room.get("secret_key"):
         session_secret_key = str(uuid.uuid4())
         await rooms_collection.update_one(
             {"sid": sid},
@@ -395,17 +431,49 @@ async def panel(request: Request, sid: str):
                 "$set": {
                     "secret_key": session_secret_key,
                     "admin_uid": user_uid,
-                    "updated_at": datetime.now(timezone.utc)
+                    "admin_last_heartbeat": now,
+                    "updated_at": now
                 }
             }
         )
         request.session["secret_key"] = session_secret_key
         user_secret_key = session_secret_key
+    else:
+        user_secret_key = request.session.get("secret_key")
 
     user_realtime_token = request.session.get("realtime_token", "")
     is_realtime_enabled = await is_realtime_authorized(request.session)
 
     return templates.TemplateResponse("panel.html", {"request": request, "sid": sid, "user_uid": user_uid, "user_secret_key": user_secret_key, "user_realtime_token": user_realtime_token, "is_realtime_enabled": is_realtime_enabled})
+
+@app.post("/heartbeat/{sid}")
+async def heartbeat(request: Request, sid: str):
+    """Update admin heartbeat to maintain session lock"""
+    user_uid = request.session.get("user_uid")
+    user_secret_key = request.session.get("secret_key")
+
+    if not user_uid or not user_secret_key:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    # Verify this user is the current admin
+    room = await rooms_collection.find_one({"sid": sid})
+    if not room:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    if room.get("admin_uid") == user_uid and room.get("secret_key") == user_secret_key:
+        # Update heartbeat
+        await rooms_collection.update_one(
+            {"sid": sid},
+            {
+                "$set": {
+                    "admin_last_heartbeat": datetime.now(timezone.utc),
+                    "updated_at": datetime.now(timezone.utc)
+                }
+            }
+        )
+        return {"status": "ok"}
+
+    raise HTTPException(status_code=403, detail="Not the current admin")
 
 @app.post("/release-admin/{sid}")
 async def release_admin(request: Request, sid: str):
@@ -429,6 +497,7 @@ async def release_admin(request: Request, sid: str):
                 "$set": {
                     "secret_key": None,
                     "admin_uid": None,
+                    "admin_last_heartbeat": None,
                     "updated_at": datetime.now(timezone.utc)
                 }
             }

--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -335,38 +335,6 @@ async def rt(request: Request, id: str):
     sliced_data["transcriptions"] = sliced_data["transcriptions"][-50:]
     return templates.TemplateResponse("rt.html", {"request": request, "id": id, "data": sliced_data})
   
-@app.post("/create-session", response_class=HTMLResponse)
-async def create_session(request: Request, sid: str = Form(...)):
-    # Check if room already exists using Motor
-    existing_room = await rooms_collection.find_one({"sid": sid})
-    if existing_room:
-        return HTMLResponse(content="""
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8" />
-        </head>
-        <body>
-            <h1>Session already exists</h1>
-            <script>
-                alert("Session id already exists, go to panel or use another one.");
-                window.location.href = "/";
-            </script>
-        </body>
-        </html>
-        """)
-
-    # Create new room without secret_key (will be set by first user)
-    await rooms_collection.insert_one({
-        "sid": sid,
-        "secret_key": None,
-        "admin_uid": None,
-        "admin_last_heartbeat": None,
-        "created_at": datetime.now(timezone.utc),
-        "extra": {}
-    })
-
-    return RedirectResponse(url=f"/panel/{sid}", status_code=303)
-
 @app.get("/panel/{sid}", response_class=HTMLResponse)
 async def panel(request: Request, sid: str):
     # Ensure user has a UID
@@ -375,10 +343,19 @@ async def panel(request: Request, sid: str):
         user_uid = str(uuid.uuid4())
         request.session["user_uid"] = user_uid
 
-    # Find the room
+    # Find or create the room
     room = await rooms_collection.find_one({"sid": sid})
     if not room:
-        raise HTTPException(status_code=404, detail="Session not found")
+        # Create new room without secret_key (will be set by first user)
+        await rooms_collection.insert_one({
+            "sid": sid,
+            "secret_key": None,
+            "admin_uid": None,
+            "admin_last_heartbeat": None,
+            "created_at": datetime.now(timezone.utc),
+            "extra": {}
+        })
+        room = await rooms_collection.find_one({"sid": sid})
 
     # Admin timeout: 30 seconds
     ADMIN_TIMEOUT = 30

--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 # Add session middleware
-app.add_middleware(SessionMiddleware, secret_key=str(uuid.uuid4()))
+app.add_middleware(SessionMiddleware, secret_key=SETTINGS.get("SECRET_KEY", str(uuid.uuid4())))
 
 # Setup templates
 timestamp = datetime.now(timezone.utc).timestamp()
@@ -88,7 +88,7 @@ youtube_data_cache = {}
 import redis.asyncio as redis
 redis_client = redis.from_url(REDIS_URL, decode_responses=True)
 
-async def is_realtime_authorized(session: dict, data: dict = None) -> bool:
+async def is_realtime_authorized(session: dict, data: dict | None = None) -> bool:
     """Check if the socket is authorized to use server-side realtime features.
 
     Returns True if:

--- a/live_server/app/static/js/realtime.js
+++ b/live_server/app/static/js/realtime.js
@@ -8,7 +8,7 @@ socket.on('connect', function () {
   console.log('WebSocket connection opened');
 
   // Join the session room
-  socket.emit('join_session', { session_id: sessionId, secret_key: user_secret_key, realtime_token: user_realtime_token });
+  socket.emit('join_session', { session_id: sessionId, secret_key: user_secret_key, realtime_token: user_realtime_token, user_uid: user_uid });
 });
 
 socket.on('disconnect', function () {

--- a/live_server/app/templates/index.html
+++ b/live_server/app/templates/index.html
@@ -72,7 +72,7 @@
                     </ul>
                 </div>
                 <div class="md:w-1/2 p-10 flex flex-col justify-center">
-                    <form id="create-form" class="space-y-6" action="{{ url_for('create_session') }}" method="post">
+                    <form id="create-form" class="space-y-6">
                         <div>
                             <label for="session-id" class="block text-sm font-medium text-gray-700 mb-2">Session
                                 ID</label>
@@ -81,7 +81,7 @@
                                 placeholder="e.g., my-meeting-01" required>
                         </div>
                         <div class="space-y-3">
-                            <button type="submit" target="rt"
+                            <button type="submit"
                                 class="w-full bg-indigo-600 text-white font-bold py-3 px-4 rounded-lg hover:bg-indigo-700 transition duration-300 shadow-md flex justify-center items-center group">
                                 Start Session
                             </button>
@@ -104,5 +104,12 @@
 
 {% block scripts %}
 <script>
+  document.getElementById('create-form').addEventListener('submit', function(e) {
+    e.preventDefault()
+    const sid = document.getElementById('session-id').value.trim()
+    if (sid) {
+      window.location.href = `/panel/${encodeURIComponent(sid)}`
+    }
+  })
 </script>
 {% endblock %}

--- a/live_server/app/templates/panel.html
+++ b/live_server/app/templates/panel.html
@@ -133,8 +133,14 @@
 <script>
   const sid = "{{ sid }}"
   const sessionId = "{{ sid }}"
+  const user_uid = "{{ user_uid }}"
   const user_secret_key = "{{ user_secret_key }}"
   const user_realtime_token = "{{ user_realtime_token }}"
+
+  // Sync user_uid with localStorage for persistence across sessions
+  if (user_uid) {
+    localStorage.setItem('user_uid', user_uid)
+  }
 
   // ── Mic toggle ───────────────────────────────────────────────────────────
 
@@ -168,6 +174,13 @@
       micBtn.title = 'Start microphone'
     }
   }
+
+  // Release admin lock when leaving the page
+  window.addEventListener('beforeunload', function () {
+    if (user_secret_key) {
+      navigator.sendBeacon(`/release-admin/${sid}`, new Blob([JSON.stringify({})], { type: 'application/json' }))
+    }
+  })
 
   document.addEventListener('DOMContentLoaded', function () {
     // ── Set full viewer URL ───────────────────────────────────────────────────

--- a/live_server/app/templates/panel.html
+++ b/live_server/app/templates/panel.html
@@ -175,8 +175,26 @@
     }
   }
 
-  // Release admin lock when leaving the page
+  // Send heartbeat every 10 seconds to maintain admin lock
+  let heartbeatInterval = null
+  if (user_secret_key) {
+    heartbeatInterval = setInterval(async function () {
+      try {
+        await fetch(`/heartbeat/${sid}`, {
+          method: 'POST',
+          credentials: 'same-origin'
+        })
+      } catch (error) {
+        console.error('Heartbeat failed:', error)
+      }
+    }, 10000)
+  }
+
+  // Release admin lock when leaving the page (best-effort)
   window.addEventListener('beforeunload', function () {
+    if (heartbeatInterval) {
+      clearInterval(heartbeatInterval)
+    }
     if (user_secret_key) {
       navigator.sendBeacon(`/release-admin/${sid}`, new Blob([JSON.stringify({})], { type: 'application/json' }))
     }


### PR DESCRIPTION
## Summary

This PR addresses a security vulnerability where session secrets were exposed in browser URLs, and redesigns the session authentication model to be more robust and self-managing.

## What Changed

### Security: Remove secrets from URL query parameters

`secret_key` and `realtime_token` were previously passed as URL query parameters (e.g. `/panel/{sid}?secret_key=...`), which exposed them in:
- Browser history
- Server access logs
- HTTP Referer headers

These are now stored exclusively in server-side session storage. The `Query` import from FastAPI was removed as it is no longer needed.

### Authentication: First-user-becomes-admin model

The previous model required a secret to be generated at session creation time and passed to the user via URL. The new model works as follows:

1. Every user is assigned a permanent `user_uid` stored in both the server session cookie and browser `localStorage`.
2. When a user accesses `/panel/{sid}`, the server checks whether an active admin is already connected.
3. If no admin is connected (or the previous admin lock has expired), the requesting user becomes the admin and receives a freshly generated `secret_key` stored only in their session.
4. If an active admin is already connected, the request is rejected with a 403.

### Admin lock release: Hybrid WebSocket disconnect + HTTP heartbeat

To prevent sessions from becoming permanently locked when an admin closes their browser, two complementary mechanisms are used.

**Primary - WebSocket disconnect detection (immediate):**
- When the admin's Socket.IO connection closes, the `disconnect` handler checks if the disconnecting socket belonged to the admin of a session.
- If so, the admin lock (`secret_key`, `admin_uid`, `admin_last_heartbeat`) is cleared immediately in the database.
- This handles the vast majority of cases: normal page close, browser crash, force quit.

**Fallback - HTTP heartbeat with 30-second timeout:**
- The admin panel sends a POST to `/heartbeat/{sid}` every 10 seconds.
- The `/panel/{sid}` endpoint checks `admin_last_heartbeat` on each access; if it is older than 30 seconds, the lock is considered expired and cleared automatically.
- A best-effort `navigator.sendBeacon` call to `/release-admin/{sid}` is also made on `beforeunload`.
- This fallback catches edge cases where the WebSocket connection stays open but the tab is frozen or suspended.

### Simplified flow: session creation merged into `/panel/{sid}`

The separate `POST /create-session` endpoint was removed. `GET /panel/{sid}` now creates the room in MongoDB if it does not already exist, making session creation implicit on first access. The index page form was updated to navigate directly to `/panel/{sid}` via client-side JavaScript instead of submitting a POST request.

## Implementation Details

- `admin_uid`, `secret_key`, and `admin_last_heartbeat` are stored per-room in MongoDB.
- `user_uid` is stored in the Starlette session cookie and mirrored to `localStorage` in the browser for persistence.
- The `join_session` Socket.IO event was updated to accept and store `user_uid` and `session_id` in the Socket.IO session, enabling the disconnect handler to identify which room the admin belonged to.
- `user_uid` is passed from `realtime.js` when emitting `join_session`.
- New HTTP endpoints added: `POST /heartbeat/{sid}` and `POST /release-admin/{sid}`.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)