### PR TITLE
Add email OTP login and admin dashboard for realtime transcription access (Vibe Kanban)

### DIFF
--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -18,7 +18,7 @@ import redis.asyncio as redis
 import socketio
 from cachetools import TTLCache
 from fastapi import FastAPI, Request, HTTPException, Depends
-from fastapi.responses import HTMLResponse, Response
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi_limiter import FastAPILimiter
@@ -28,9 +28,21 @@ from starlette.middleware.sessions import SessionMiddleware
 dotenv.load_dotenv(override=True)
 
 from .config import SETTINGS, REDIS_URL
-from .database import rooms_collection, transcription_store_collection, realtime_tokens_collection, init_indexes
+try:
+    from .config import EMAIL_SETTINGS
+except ImportError:
+    EMAIL_SETTINGS = {}
+from .database import rooms_collection, transcription_store_collection, realtime_tokens_collection, users_collection, init_indexes
 from .logger_config import setup_logger, log_exception
 from .scribe_manager import ScribeSessionManager
+from .email_auth import (
+    validate_email_format,
+    generate_otp,
+    store_otp,
+    verify_otp,
+    send_otp_email,
+    get_or_create_user,
+)
 
 # Setup logger
 logger = setup_logger(__name__)
@@ -173,12 +185,13 @@ async def is_realtime_authorized(session: dict, data: dict | None = None) -> boo
 
     Returns True if:
     1. The socket is an admin connection (global SECRET_KEY), OR
-    2. No tokens exist in DB (no restrictions configured), OR
-    3. A valid user_uid is found in data or session that matches a token
+    2. The user logged in via email and has realtime_enabled=True, OR
+    3. No tokens exist in DB (no restrictions configured), OR
+    4. A valid user_uid is found in data or session that matches a realtime token
     """
     if session.get('admin'):
         return True
-        
+
     token = None
     if data and isinstance(data, dict):
         token = data.get('user_uid')
@@ -192,7 +205,12 @@ async def is_realtime_authorized(session: dict, data: dict | None = None) -> boo
     if not is_valid:
         return False
 
-    # If no tokens in DB, allow everyone with a token (backward compat)
+    # Check email-based user permission
+    user_doc = await users_collection.find_one({"user_uid": token})
+    if user_doc and user_doc.get("realtime_enabled"):
+        return True
+
+    # If no realtime tokens in DB, allow everyone with a user_uid (backward compat)
     if await realtime_tokens_collection.count_documents({}, limit=1) == 0:
         return True
 
@@ -293,6 +311,115 @@ async def delete_token(request: Request, token: str):
     if result.deleted_count == 0:
         raise HTTPException(status_code=404, detail="Token not found")
     return {"deleted": token}
+
+
+# ---------------------------------------------------------------------------
+# Email login routes
+# ---------------------------------------------------------------------------
+
+def _get_session_email(request: Request) -> str | None:
+    return request.session.get("email")
+
+
+def _require_admin_email(request: Request):
+    email = _get_session_email(request)
+    if not email:
+        raise HTTPException(status_code=401, detail="Not logged in")
+    admin_emails = [e.lower() for e in EMAIL_SETTINGS.get("ADMIN_EMAILS", [])]
+    if email.lower() not in admin_emails:
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return email
+
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    email = _get_session_email(request)
+    if email:
+        admin_emails = [e.lower() for e in EMAIL_SETTINGS.get("ADMIN_EMAILS", [])]
+        target = "/dashboard" if email.lower() in admin_emails else "/"
+        return RedirectResponse(url=target, status_code=302)
+    return templates.TemplateResponse("login.html", {"request": request})
+
+
+@app.post("/auth/send-otp", dependencies=[Depends(RateLimiter(times=5, seconds=60))])
+async def send_otp(request: Request):
+    body = await request.json()
+    email = body.get("email", "").strip()
+    if not validate_email_format(email):
+        raise HTTPException(status_code=400, detail="Invalid email address")
+    otp = generate_otp()
+    await store_otp(redis_client, email, otp)
+    try:
+        await send_otp_email(email, otp, EMAIL_SETTINGS)
+    except Exception as e:
+        log_exception(logger, e, f"Failed to send OTP email to {email}")
+        raise HTTPException(status_code=500, detail="Failed to send email")
+    return {"status": "sent"}
+
+
+@app.post("/auth/verify-otp", dependencies=[Depends(RateLimiter(times=10, seconds=60))])
+async def verify_otp_endpoint(request: Request):
+    body = await request.json()
+    email = body.get("email", "").strip()
+    otp = body.get("otp", "").strip()
+    if not validate_email_format(email):
+        raise HTTPException(status_code=400, detail="Invalid email address")
+    if not otp or not re.match(r'^\d{4}$', otp):
+        raise HTTPException(status_code=400, detail="Invalid OTP format")
+
+    if not await verify_otp(redis_client, email, otp):
+        raise HTTPException(status_code=401, detail="Invalid or expired code")
+
+    # Reuse existing user_uid from session or generate a new one
+    user_uid = request.session.get("user_uid") or str(uuid.uuid4())
+    await get_or_create_user(users_collection, email, user_uid)
+
+    request.session["email"] = email.lower()
+    request.session["user_uid"] = user_uid
+
+    admin_emails = [e.lower() for e in EMAIL_SETTINGS.get("ADMIN_EMAILS", [])]
+    is_admin = email.lower() in admin_emails
+    return {"status": "ok", "is_admin": is_admin, "redirect": "/dashboard" if is_admin else "/"}
+
+
+@app.get("/logout")
+async def logout(request: Request):
+    request.session.clear()
+    return RedirectResponse(url="/login", status_code=302)
+
+
+@app.get("/dashboard", response_class=HTMLResponse, dependencies=[Depends(RateLimiter(times=30, seconds=60))])
+async def dashboard(request: Request):
+    _require_admin_email(request)
+    users = await users_collection.find({}, {"_id": 0}).to_list(length=1000)
+    # Convert datetimes to ISO strings for template rendering
+    for u in users:
+        if isinstance(u.get("created_at"), datetime):
+            u["created_at"] = u["created_at"].isoformat()
+        if isinstance(u.get("last_login_at"), datetime):
+            u["last_login_at"] = u["last_login_at"].isoformat()
+    return templates.TemplateResponse("dashboard.html", {"request": request, "users": users, "current_email": _get_session_email(request)})
+
+
+@app.post("/api/users/{email}/realtime", dependencies=[Depends(RateLimiter(times=30, seconds=60))])
+async def set_user_realtime(request: Request, email: str):
+    """Toggle realtime_enabled for a user (admin only)."""
+    _require_admin_email(request)
+    if not validate_email_format(email):
+        raise HTTPException(status_code=400, detail="Invalid email address")
+    body = await request.json()
+    enabled = body.get("enabled")
+    if not isinstance(enabled, bool):
+        raise HTTPException(status_code=400, detail="'enabled' must be a boolean")
+    from pymongo import ReturnDocument
+    result = await users_collection.find_one_and_update(
+        {"email": email.lower()},
+        {"$set": {"realtime_enabled": enabled}},
+        return_document=ReturnDocument.AFTER,
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"email": result["email"], "realtime_enabled": result["realtime_enabled"]}
 
 
 @app.get("/api/session/{sid}/languages", dependencies=[Depends(RateLimiter(times=30, seconds=60))])

--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -4,7 +4,6 @@
 # See LICENSE for details.
 
 import asyncio
-import hmac
 import json
 import re
 import uuid
@@ -32,7 +31,7 @@ try:
     from .config import EMAIL_SETTINGS
 except ImportError:
     EMAIL_SETTINGS = {}
-from .database import rooms_collection, transcription_store_collection, realtime_tokens_collection, users_collection, init_indexes
+from .database import rooms_collection, transcription_store_collection, users_collection, init_indexes
 from .logger_config import setup_logger, log_exception
 from .scribe_manager import ScribeSessionManager
 from .email_auth import (
@@ -184,38 +183,26 @@ async def is_realtime_authorized(session: dict, data: dict | None = None) -> boo
     """Check if the socket is authorized to use server-side realtime features.
 
     Returns True if:
-    1. The socket is an admin connection (global SECRET_KEY), OR
-    2. The user logged in via email and has realtime_enabled=True, OR
-    3. No tokens exist in DB (no restrictions configured), OR
-    4. A valid user_uid is found in data or session that matches a realtime token
+    1. The socket is a global admin connection, OR
+    2. The user logged in via email and has realtime_enabled=True
     """
     if session.get('admin'):
         return True
 
-    token = None
+    user_uid = None
     if data and isinstance(data, dict):
-        token = data.get('user_uid')
-    if not token:
-        token = session.get('user_uid')
-    if not token:
+        user_uid = data.get('user_uid')
+    if not user_uid:
+        user_uid = session.get('user_uid')
+    if not user_uid:
         return False
 
-    # Validate token to prevent NoSQL injection
-    is_valid, _ = validate_query_param(token, "user_uid")
+    is_valid, _ = validate_query_param(user_uid, "user_uid")
     if not is_valid:
         return False
 
-    # Check email-based user permission
-    user_doc = await users_collection.find_one({"user_uid": token})
-    if user_doc and user_doc.get("realtime_enabled"):
-        return True
-
-    # If no realtime tokens in DB, allow everyone with a user_uid (backward compat)
-    if await realtime_tokens_collection.count_documents({}, limit=1) == 0:
-        return True
-
-    doc = await realtime_tokens_collection.find_one({"token": token})
-    return doc is not None
+    user_doc = await users_collection.find_one({"user_uid": user_uid})
+    return bool(user_doc and user_doc.get("realtime_enabled"))
 
 
 async def verify_socket_auth(socket_id: str, session_id: str, secret_key: str) -> bool:
@@ -252,15 +239,6 @@ async def _ensure_socket_verified(socket_id, session, secret_key, session_id) ->
     return True
 
 
-def _verify_admin(request: Request):
-    """Verify admin via Authorization: Bearer {SECRET_KEY} header."""
-    auth_header = request.headers.get("authorization", "")
-    if not auth_header.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing Authorization header")
-    provided = auth_header[7:]
-    if not hmac.compare_digest(provided, SETTINGS["SECRET_KEY"]):
-        raise HTTPException(status_code=403, detail="Invalid SECRET_KEY")
-
 
 async def _verify_session_admin(request: Request, sid: str):
     """Verify the request user is the admin of the given session. Returns the room doc."""
@@ -274,43 +252,6 @@ async def _verify_session_admin(request: Request, sid: str):
     if room.get("admin_uid") != user_uid or room.get("secret_key") != user_secret_key:
         raise HTTPException(status_code=403, detail="Forbidden")
     return room
-
-
-@app.get("/api/tokens", dependencies=[Depends(RateLimiter(times=20, seconds=60))])
-async def list_tokens(request: Request):
-    """List all realtime tokens (admin only)."""
-    _verify_admin(request)
-    docs = await realtime_tokens_collection.find({}, {"_id": 0}).to_list(length=1000)
-    return docs
-
-
-@app.post("/api/tokens", dependencies=[Depends(RateLimiter(times=20, seconds=60))])
-async def create_token(request: Request):
-    """Create a new realtime token (admin only)."""
-    _verify_admin(request)
-    body = await request.json() if request.headers.get("content-type") == "application/json" else {}
-    token = str(uuid.uuid4())
-    doc = {
-        "token": token,
-        "label": body.get("label", ""),
-        "created_at": datetime.now(timezone.utc),
-    }
-    await realtime_tokens_collection.insert_one(doc)
-    return {"token": token, "label": doc["label"], "created_at": doc["created_at"].isoformat()}
-
-
-@app.delete("/api/tokens/{token}", dependencies=[Depends(RateLimiter(times=20, seconds=60))])
-async def delete_token(request: Request, token: str):
-    """Revoke a realtime token (admin only)."""
-    _verify_admin(request)
-
-    # Sanitize token parameter to prevent NoSQL injection
-    token = sanitize_query_param(token, "token")
-
-    result = await realtime_tokens_collection.delete_one({"token": token})
-    if result.deleted_count == 0:
-        raise HTTPException(status_code=404, detail="Token not found")
-    return {"deleted": token}
 
 
 # ---------------------------------------------------------------------------

--- a/live_server/app/config.example.py
+++ b/live_server/app/config.example.py
@@ -3,6 +3,20 @@ SETTINGS = {
   "SECRET_KEY": "your-secret-key"
 }
 
+EMAIL_SETTINGS = {
+  # List of email addresses with admin dashboard access
+  "ADMIN_EMAILS": ["admin@example.com"],
+
+  # SMTP configuration for sending OTP emails
+  # Leave SMTP_HOST empty to disable email sending (OTP will be logged instead)
+  "SMTP_HOST": "",
+  "SMTP_PORT": 587,
+  "SMTP_USERNAME": "",
+  "SMTP_PASSWORD": "",
+  "SMTP_FROM": "noreply@example.com",
+  "SMTP_USE_TLS": True,
+}
+
 MONGODB_SETTINGS = {
     'db': 'opentranslive-db',
     'host': 'mongodb',

--- a/live_server/app/database.py
+++ b/live_server/app/database.py
@@ -9,8 +9,11 @@ db = client[MONGODB_SETTINGS.get('db', 'opentranslive-db')]
 rooms_collection = db['room']
 transcription_store_collection = db['transcription_store']
 realtime_tokens_collection = db['realtime_tokens']
+users_collection = db['users']
 
 
 async def init_indexes():
     await rooms_collection.create_index([("sid", ASCENDING)], unique=True)
     await transcription_store_collection.create_index([("sid", ASCENDING), ("created_at", DESCENDING)])
+    await users_collection.create_index([("email", ASCENDING)], unique=True)
+    await users_collection.create_index([("user_uid", ASCENDING)])

--- a/live_server/app/database.py
+++ b/live_server/app/database.py
@@ -8,7 +8,6 @@ db = client[MONGODB_SETTINGS.get('db', 'opentranslive-db')]
 
 rooms_collection = db['room']
 transcription_store_collection = db['transcription_store']
-realtime_tokens_collection = db['realtime_tokens']
 users_collection = db['users']
 
 

--- a/live_server/app/email_auth.py
+++ b/live_server/app/email_auth.py
@@ -1,0 +1,97 @@
+# This file is part of g0v/realtime_transcribe.
+# Copyright (c) 2025 Sean Gau
+# Licensed under the GNU AGPL v3.0
+# See LICENSE for details.
+
+import random
+import re
+from datetime import datetime, timezone
+
+from pymongo import ReturnDocument
+
+from .logger_config import setup_logger
+
+logger = setup_logger(__name__)
+
+_EMAIL_RE = re.compile(r'^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$')
+
+OTP_TTL = 600  # seconds (10 minutes)
+
+
+def validate_email_format(email: str) -> bool:
+    if not isinstance(email, str):
+        return False
+    return bool(_EMAIL_RE.match(email.strip()))
+
+
+def generate_otp() -> str:
+    return f"{random.randint(0, 9999):04d}"
+
+
+async def store_otp(redis_client, email: str, otp: str) -> None:
+    key = f"auth:otp:{email.lower()}"
+    await redis_client.setex(key, OTP_TTL, otp)
+
+
+async def verify_otp(redis_client, email: str, otp: str) -> bool:
+    key = f"auth:otp:{email.lower()}"
+    stored = await redis_client.get(key)
+    if stored is None:
+        return False
+    if stored != otp:
+        return False
+    await redis_client.delete(key)
+    return True
+
+
+async def send_otp_email(email: str, otp: str, email_settings: dict) -> None:
+    smtp_host = email_settings.get("SMTP_HOST", "")
+    if not smtp_host:
+        logger.info(f"[DEV MODE] OTP for {email}: {otp}")
+        return
+
+    import aiosmtplib
+    from email.mime.text import MIMEText
+
+    smtp_from = email_settings.get("SMTP_FROM", "noreply@example.com")
+    subject = "Your login code"
+    body = (
+        f"Your OpenTransLive login code is: {otp}\n\n"
+        f"This code expires in 10 minutes.\n"
+        f"If you did not request this, ignore this email."
+    )
+
+    msg = MIMEText(body, "plain", "utf-8")
+    msg["Subject"] = subject
+    msg["From"] = smtp_from
+    msg["To"] = email
+
+    await aiosmtplib.send(
+        msg,
+        hostname=smtp_host,
+        port=email_settings.get("SMTP_PORT", 587),
+        username=email_settings.get("SMTP_USERNAME") or None,
+        password=email_settings.get("SMTP_PASSWORD") or None,
+        use_tls=False,
+        start_tls=email_settings.get("SMTP_USE_TLS", True),
+    )
+
+
+async def get_or_create_user(users_collection, email: str, user_uid: str) -> dict:
+    """Upsert a user by email. Always updates user_uid on login."""
+    now = datetime.now(timezone.utc)
+    email = email.lower().strip()
+    result = await users_collection.find_one_and_update(
+        {"email": email},
+        {
+            "$set": {"user_uid": user_uid, "last_login_at": now},
+            "$setOnInsert": {
+                "email": email,
+                "realtime_enabled": False,
+                "created_at": now,
+            },
+        },
+        upsert=True,
+        return_document=ReturnDocument.AFTER,
+    )
+    return result

--- a/live_server/app/templates/dashboard.html
+++ b/live_server/app/templates/dashboard.html
@@ -1,0 +1,122 @@
+{% extends "base.html" %}
+{% block title %}OpenTransLive - Admin Dashboard{% endblock %}
+
+{% block content %}
+<div class="min-h-screen bg-gray-900 text-gray-100 font-sans">
+
+  <!-- Top bar -->
+  <header class="bg-gray-800 border-b border-gray-700 px-6 py-3 flex items-center justify-between">
+    <span class="font-bold text-gray-100 tracking-tight">Admin Dashboard</span>
+    <div class="flex items-center gap-4">
+      <span class="text-xs text-gray-500">{{ current_email }}</span>
+      <a href="/logout" class="text-xs text-gray-400 hover:text-gray-200 transition-colors border border-gray-600 rounded px-2 py-1">Logout</a>
+    </div>
+  </header>
+
+  <main class="max-w-3xl mx-auto px-4 py-8">
+
+    <div class="mb-6">
+      <h2 class="text-lg font-semibold text-gray-100">Realtime Transcription Access</h2>
+      <p class="mt-1 text-sm text-gray-500">
+        Toggle realtime transcription permission for each user.
+        Users must log in via <a href="/login" class="underline text-gray-400 hover:text-gray-200">/login</a> before they appear here.
+      </p>
+    </div>
+
+    {% if users %}
+    <div class="bg-gray-800 border border-gray-700 rounded-xl overflow-hidden">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-gray-700 text-left text-xs text-gray-500 uppercase tracking-wider">
+            <th class="px-4 py-3 font-semibold">Email</th>
+            <th class="px-4 py-3 font-semibold">Last login</th>
+            <th class="px-4 py-3 font-semibold text-right">Realtime access</th>
+          </tr>
+        </thead>
+        <tbody id="user-table-body">
+          {% for user in users %}
+          <tr class="border-b border-gray-700 last:border-0" data-email="{{ user.email }}">
+            <td class="px-4 py-3 font-mono text-xs text-gray-200 break-all">{{ user.email }}</td>
+            <td class="px-4 py-3 text-xs text-gray-500">
+              {% if user.last_login_at %}
+                {{ user.last_login_at[:19].replace('T', ' ') }} UTC
+              {% else %}
+                —
+              {% endif %}
+            </td>
+            <td class="px-4 py-3 text-right">
+              <button
+                class="realtime-toggle px-3 py-1 rounded text-xs font-semibold transition-colors {% if user.realtime_enabled %}bg-green-700 hover:bg-green-600 text-green-100{% else %}bg-gray-700 hover:bg-gray-600 text-gray-300{% endif %}"
+                data-email="{{ user.email }}"
+                data-enabled="{{ 'true' if user.realtime_enabled else 'false' }}"
+              >
+                {% if user.realtime_enabled %}Enabled{% else %}Disabled{% endif %}
+              </button>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <div class="bg-gray-800 border border-gray-700 rounded-xl px-6 py-10 text-center text-sm text-gray-500">
+      No users yet. Users appear here after logging in at <a href="/login" class="underline hover:text-gray-300">/login</a>.
+    </div>
+    {% endif %}
+
+    <div id="action-status" class="mt-4 text-xs text-gray-500 min-h-4"></div>
+  </main>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  const statusEl = document.getElementById('action-status')
+
+  function setStatus(msg, isError) {
+    statusEl.textContent = msg
+    statusEl.style.color = isError ? '#f87171' : '#6b7280'
+  }
+
+  document.querySelectorAll('.realtime-toggle').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const email = btn.dataset.email
+      const currentEnabled = btn.dataset.enabled === 'true'
+      const newEnabled = !currentEnabled
+
+      btn.disabled = true
+      const prev = btn.textContent
+      btn.textContent = '...'
+
+      try {
+        const res = await fetch(`/api/users/${encodeURIComponent(email)}/realtime`, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enabled: newEnabled })
+        })
+        if (!res.ok) {
+          const data = await res.json()
+          setStatus(data.detail || 'Error updating user.', true)
+          btn.textContent = prev
+          return
+        }
+        const data = await res.json()
+        btn.dataset.enabled = data.realtime_enabled ? 'true' : 'false'
+        btn.textContent = data.realtime_enabled ? 'Enabled' : 'Disabled'
+        if (data.realtime_enabled) {
+          btn.className = 'realtime-toggle px-3 py-1 rounded text-xs font-semibold transition-colors bg-green-700 hover:bg-green-600 text-green-100'
+        } else {
+          btn.className = 'realtime-toggle px-3 py-1 rounded text-xs font-semibold transition-colors bg-gray-700 hover:bg-gray-600 text-gray-300'
+        }
+        setStatus(`Updated ${email}.`, false)
+      } catch (e) {
+        setStatus('Network error.', true)
+        btn.textContent = prev
+      } finally {
+        btn.disabled = false
+      }
+    })
+  })
+</script>
+{% endblock %}

--- a/live_server/app/templates/login.html
+++ b/live_server/app/templates/login.html
@@ -1,0 +1,168 @@
+{% extends "base.html" %}
+{% block title %}OpenTransLive - Login{% endblock %}
+
+{% block content %}
+<div class="min-h-screen bg-gray-900 flex items-center justify-center px-4">
+  <div class="w-full max-w-sm">
+    <div class="mb-8 text-center">
+      <h1 class="text-2xl font-bold text-gray-100 tracking-tight">OpenTransLive</h1>
+      <p class="mt-1 text-sm text-gray-500">Sign in to continue</p>
+    </div>
+
+    <!-- Step 1: Email input -->
+    <div id="step-email" class="bg-gray-800 border border-gray-700 rounded-xl p-6 flex flex-col gap-4">
+      <label class="text-sm font-semibold text-gray-300" for="email-input">Email address</label>
+      <input
+        id="email-input"
+        type="email"
+        autocomplete="email"
+        placeholder="you@example.com"
+        class="bg-gray-900 border border-gray-600 text-gray-100 text-sm rounded-lg px-3 py-2 outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-600"
+      />
+      <div id="email-error" class="hidden text-xs text-red-400"></div>
+      <button
+        id="send-otp-btn"
+        class="mt-1 w-full bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white text-sm font-semibold py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        Send code
+      </button>
+    </div>
+
+    <!-- Step 2: OTP input (hidden initially) -->
+    <div id="step-otp" class="hidden bg-gray-800 border border-gray-700 rounded-xl p-6 flex flex-col gap-4">
+      <div>
+        <p class="text-sm font-semibold text-gray-300">Enter the 4-digit code</p>
+        <p id="otp-hint" class="mt-1 text-xs text-gray-500"></p>
+      </div>
+      <input
+        id="otp-input"
+        type="text"
+        inputmode="numeric"
+        pattern="[0-9]{4}"
+        maxlength="4"
+        placeholder="0000"
+        class="bg-gray-900 border border-gray-600 text-gray-100 text-2xl font-mono tracking-widest text-center rounded-lg px-3 py-3 outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-700"
+      />
+      <div id="otp-error" class="hidden text-xs text-red-400"></div>
+      <button
+        id="verify-otp-btn"
+        class="mt-1 w-full bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white text-sm font-semibold py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        Verify
+      </button>
+      <button
+        id="back-btn"
+        class="text-xs text-gray-500 hover:text-gray-300 transition-colors text-center"
+      >
+        Use a different email
+      </button>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  const stepEmail = document.getElementById('step-email')
+  const stepOtp = document.getElementById('step-otp')
+  const emailInput = document.getElementById('email-input')
+  const otpInput = document.getElementById('otp-input')
+  const sendOtpBtn = document.getElementById('send-otp-btn')
+  const verifyOtpBtn = document.getElementById('verify-otp-btn')
+  const backBtn = document.getElementById('back-btn')
+  const emailError = document.getElementById('email-error')
+  const otpError = document.getElementById('otp-error')
+  const otpHint = document.getElementById('otp-hint')
+
+  let currentEmail = ''
+
+  function showError(el, msg) {
+    el.textContent = msg
+    el.classList.remove('hidden')
+  }
+
+  function hideError(el) {
+    el.classList.add('hidden')
+    el.textContent = ''
+  }
+
+  sendOtpBtn.addEventListener('click', async () => {
+    hideError(emailError)
+    const email = emailInput.value.trim()
+    if (!email) {
+      showError(emailError, 'Please enter your email address.')
+      return
+    }
+    sendOtpBtn.disabled = true
+    sendOtpBtn.textContent = 'Sending...'
+    try {
+      const res = await fetch('/auth/send-otp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        showError(emailError, data.detail || 'Failed to send code.')
+        return
+      }
+      currentEmail = email
+      otpHint.textContent = `A 4-digit code was sent to ${email}.`
+      stepEmail.classList.add('hidden')
+      stepOtp.classList.remove('hidden')
+      otpInput.focus()
+    } catch (e) {
+      showError(emailError, 'Network error. Please try again.')
+    } finally {
+      sendOtpBtn.disabled = false
+      sendOtpBtn.textContent = 'Send code'
+    }
+  })
+
+  emailInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') sendOtpBtn.click()
+  })
+
+  verifyOtpBtn.addEventListener('click', async () => {
+    hideError(otpError)
+    const otp = otpInput.value.trim()
+    if (!/^\d{4}$/.test(otp)) {
+      showError(otpError, 'Please enter the 4-digit code.')
+      return
+    }
+    verifyOtpBtn.disabled = true
+    verifyOtpBtn.textContent = 'Verifying...'
+    try {
+      const res = await fetch('/auth/verify-otp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: currentEmail, otp })
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        showError(otpError, data.detail || 'Invalid or expired code.')
+        return
+      }
+      const data = await res.json()
+      window.location.href = data.redirect || '/'
+    } catch (e) {
+      showError(otpError, 'Network error. Please try again.')
+    } finally {
+      verifyOtpBtn.disabled = false
+      verifyOtpBtn.textContent = 'Verify'
+    }
+  })
+
+  otpInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') verifyOtpBtn.click()
+  })
+
+  backBtn.addEventListener('click', () => {
+    hideError(otpError)
+    otpInput.value = ''
+    stepOtp.classList.add('hidden')
+    stepEmail.classList.remove('hidden')
+    emailInput.focus()
+  })
+</script>
+{% endblock %}

--- a/live_server/pyproject.toml
+++ b/live_server/pyproject.toml
@@ -18,4 +18,5 @@ dependencies = [
     "uvicorn>=0.40.0",
     "websockets>=15.0.1",
     "cachetools>=5.0.0",
+    "aiosmtplib>=3.0.0",
 ]


### PR DESCRIPTION
## Summary

- Replace manual token management with email-based 4-digit OTP login
- Add an admin dashboard for toggling realtime transcription permission per user
- Remove the old `realtime_tokens` collection and Bearer SECRET_KEY token API

## What changed

### New: Email OTP login flow
- `GET /login` — two-step login page: enter email, then enter the 4-digit code
- `POST /auth/send-otp` — generates a 4-digit OTP, stores it in Redis with a 10-minute TTL, and sends it via SMTP (or logs it when SMTP is not configured, for development)
- `POST /auth/verify-otp` — verifies the OTP, sets the user session (`email`, `user_uid`), and redirects admin users to `/dashboard`
- `GET /logout` — clears the session and redirects to `/login`

### New: Admin dashboard
- `GET /dashboard` — lists all registered users with their realtime access status; accessible only to emails listed in `ADMIN_EMAILS`
- `POST /api/users/{email}/realtime` — toggles `realtime_enabled` for a given user

### New: `users` MongoDB collection
Schema: `email` (unique), `user_uid`, `realtime_enabled` (bool), `created_at`, `last_login_at`

Users are upserted on each successful OTP verification. The `user_uid` field links the HTTP session to the WebSocket session for realtime authorization.

### Simplified `is_realtime_authorized`
Now checks only:
1. Global admin socket connection, OR
2. `users_collection.realtime_enabled == True` for the connecting `user_uid`

### Removed: `realtime_tokens` system
- Dropped `realtime_tokens` collection and all related code
- Removed `GET /api/tokens`, `POST /api/tokens`, `DELETE /api/tokens/{token}`
- Removed `_verify_admin` (Bearer SECRET_KEY) helper

## Configuration

`EMAIL_SETTINGS` added to `config.example.py`:

```python
EMAIL_SETTINGS = {
    "ADMIN_EMAILS": ["admin@example.com"],
    "SMTP_HOST": "",        # leave empty to log OTP instead of sending
    "SMTP_PORT": 587,
    "SMTP_USERNAME": "",
    "SMTP_PASSWORD": "",
    "SMTP_FROM": "noreply@example.com",
    "SMTP_USE_TLS": True,
}
```

## New dependency

`aiosmtplib>=3.0.0` added for async SMTP sending.