### PR TITLE
live_server: track and persist audio transcription usage (Vibe Kanban)

### DIFF
--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -1089,6 +1089,16 @@ async def audio_buffer_append(socket_id, data):
         return
 
     manager = _get_or_create_scribe_manager(session_id)
+    # On first audio chunk of a new manager instance, restore previously saved usage from DB
+    # so counts survive page refreshes. Flag is set before the await to prevent double-restore.
+    if not manager._usage_restored:
+        manager._usage_restored = True
+        room_usage = await rooms_collection.find_one(
+            {"sid": session_id}, {"_id": 0, "audio_bytes": 1, "audio_chunks": 1}
+        )
+        if room_usage and room_usage.get("audio_bytes"):
+            manager.restore_usage(room_usage["audio_bytes"], room_usage.get("audio_chunks", 0))
+            _audio_usage_last_saved[session_id] = room_usage["audio_bytes"]
     await manager.push_audio(base64_audio)
     # Persist usage to DB every _AUDIO_SAVE_INTERVAL_BYTES of accumulated audio
     last_saved = _audio_usage_last_saved.get(session_id, 0)

--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -75,6 +75,10 @@ active_translation_managers: TTLCache = _ManagerTTLCache(
 )
 # Pending debounce tasks for partial transcription broadcasts, keyed by session_id.
 _partial_debounce_tasks: dict = {}
+# Audio usage save tracking: session_id -> last saved bytes
+_audio_usage_last_saved: dict = {}
+# Save audio usage to DB every 30 seconds of accumulated audio (16kHz 16-bit PCM)
+_AUDIO_SAVE_INTERVAL_BYTES = 30 * 16000 * 2
 
 
 def _get_or_create_scribe_manager(session_id) -> ScribeSessionManager:
@@ -245,6 +249,22 @@ async def _verify_session_admin(request: Request, sid: str):
     return room
 
 
+async def _save_audio_usage_to_db(session_id: str, stats: dict):
+    """Persist audio usage stats to the rooms collection."""
+    try:
+        await rooms_collection.update_one(
+            {"sid": session_id},
+            {"$set": {
+                "audio_bytes": stats["audio_bytes"],
+                "audio_duration_secs": stats["audio_duration_secs"],
+                "audio_chunks": stats["audio_chunks"],
+                "audio_usage_updated_at": datetime.now(timezone.utc),
+            }}
+        )
+    except Exception as e:
+        log_exception(logger, e, f"Error saving audio usage for {session_id}")
+
+
 # ---------------------------------------------------------------------------
 # Email login routes
 # ---------------------------------------------------------------------------
@@ -317,19 +337,22 @@ async def user_dashboard(request: Request):
         return RedirectResponse(url="/login", status_code=302)
     rooms = await rooms_collection.find(
         {"admin_uid": user_uid},
-        {"_id": 0, "sid": 1, "created_at": 1, "admin_last_heartbeat": 1}
+        {"_id": 0, "sid": 1, "created_at": 1, "admin_last_heartbeat": 1,
+         "audio_bytes": 1, "audio_duration_secs": 1}
     ).sort("created_at", -1).to_list(length=200)
     for r in rooms:
         if isinstance(r.get("created_at"), datetime):
             r["created_at"] = r["created_at"].isoformat()
         if isinstance(r.get("admin_last_heartbeat"), datetime):
             r["admin_last_heartbeat"] = r["admin_last_heartbeat"].isoformat()
+    max_audio_secs = max((r.get("audio_duration_secs") or 0 for r in rooms), default=0)
     is_realtime_enabled = await is_realtime_authorized(request.session)
     return templates.TemplateResponse("user_dashboard.html", {
         "request": request,
         "rooms": rooms,
         "current_email": email,
         "is_realtime_enabled": is_realtime_enabled,
+        "max_audio_secs": max_audio_secs,
     })
 
 
@@ -1067,4 +1090,9 @@ async def audio_buffer_append(socket_id, data):
 
     manager = _get_or_create_scribe_manager(session_id)
     await manager.push_audio(base64_audio)
+    # Persist usage to DB every _AUDIO_SAVE_INTERVAL_BYTES of accumulated audio
+    last_saved = _audio_usage_last_saved.get(session_id, 0)
+    if manager.audio_bytes_total - last_saved >= _AUDIO_SAVE_INTERVAL_BYTES:
+        _audio_usage_last_saved[session_id] = manager.audio_bytes_total
+        asyncio.create_task(_save_audio_usage_to_db(session_id, manager.get_usage_stats()))
     

--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -76,9 +76,6 @@ active_translation_managers: TTLCache = _ManagerTTLCache(
 # Pending debounce tasks for partial transcription broadcasts, keyed by session_id.
 _partial_debounce_tasks: dict = {}
 # Audio usage save tracking: session_id -> last saved bytes
-_audio_usage_last_saved: dict = {}
-# Save audio usage to DB every 30 seconds of accumulated audio (16kHz 16-bit PCM)
-_AUDIO_SAVE_INTERVAL_BYTES = 30 * 16000 * 2
 
 
 def _get_or_create_scribe_manager(session_id) -> ScribeSessionManager:
@@ -247,22 +244,6 @@ async def _verify_session_admin(request: Request, sid: str):
     if room.get("secret_key") != user_secret_key:
         raise HTTPException(status_code=403, detail="Forbidden")
     return room
-
-
-async def _save_audio_usage_to_db(session_id: str, stats: dict):
-    """Persist audio usage stats to the rooms collection."""
-    try:
-        await rooms_collection.update_one(
-            {"sid": session_id},
-            {"$set": {
-                "audio_bytes": stats["audio_bytes"],
-                "audio_duration_secs": stats["audio_duration_secs"],
-                "audio_chunks": stats["audio_chunks"],
-                "audio_usage_updated_at": datetime.now(timezone.utc),
-            }}
-        )
-    except Exception as e:
-        log_exception(logger, e, f"Error saving audio usage for {session_id}")
 
 
 # ---------------------------------------------------------------------------
@@ -795,10 +776,14 @@ async def heartbeat(request: Request, sid: str):
     sid = sanitize_query_param(sid, "session ID")
     await _verify_session_admin(request, sid)
     now = datetime.now(timezone.utc)
-    await rooms_collection.update_one(
-        {"sid": sid},
-        {"$set": {"admin_last_heartbeat": now, "updated_at": now}}
-    )
+    update = {"admin_last_heartbeat": now, "updated_at": now}
+    manager = active_scribe_managers.get(sid)
+    if manager and manager.audio_bytes_total > 0:
+        stats = manager.get_usage_stats()
+        update["audio_bytes"] = stats["audio_bytes"]
+        update["audio_duration_secs"] = stats["audio_duration_secs"]
+        update["audio_chunks"] = stats["audio_chunks"]
+    await rooms_collection.update_one({"sid": sid}, {"$set": update})
     return {"status": "ok"}
 
 @app.post("/release-admin/{sid}", dependencies=[Depends(RateLimiter(times=30, seconds=60, identifier=_get_session_uid))])
@@ -1100,11 +1085,5 @@ async def audio_buffer_append(socket_id, data):
         )
         if room_usage and room_usage.get("audio_bytes"):
             manager.restore_usage(room_usage["audio_bytes"], room_usage.get("audio_chunks", 0))
-            _audio_usage_last_saved[session_id] = room_usage["audio_bytes"]
     await manager.push_audio(base64_audio)
-    # Persist usage to DB every _AUDIO_SAVE_INTERVAL_BYTES of accumulated audio
-    last_saved = _audio_usage_last_saved.get(session_id, 0)
-    if manager.audio_bytes_total - last_saved >= _AUDIO_SAVE_INTERVAL_BYTES:
-        _audio_usage_last_saved[session_id] = manager.audio_bytes_total
-        asyncio.create_task(_save_audio_usage_to_db(session_id, manager.get_usage_stats()))
     

--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -346,13 +346,15 @@ async def user_dashboard(request: Request):
         if isinstance(r.get("admin_last_heartbeat"), datetime):
             r["admin_last_heartbeat"] = r["admin_last_heartbeat"].isoformat()
     max_audio_secs = max((r.get("audio_duration_secs") or 0 for r in rooms), default=0)
+    for r in rooms:
+        dur = r.get("audio_duration_secs") or 0
+        r["audio_pct"] = min(int(dur / max_audio_secs * 100), 100) if max_audio_secs > 0 else 0
     is_realtime_enabled = await is_realtime_authorized(request.session)
     return templates.TemplateResponse("user_dashboard.html", {
         "request": request,
         "rooms": rooms,
         "current_email": email,
         "is_realtime_enabled": is_realtime_enabled,
-        "max_audio_secs": max_audio_secs,
     })
 
 
@@ -510,7 +512,7 @@ async def get_session_audio_usage_endpoint(request: Request, sid: str):
 
     manager = active_scribe_managers.get(sid)
     if not manager:
-        return {"audio_bytes": 0, "audio_chunks": 0, "audio_duration_secs": 0.0, "session_elapsed_secs": 0.0}
+        return {"audio_bytes": 0, "audio_chunks": 0, "audio_duration_secs": 0.0}
     return manager.get_usage_stats()
 
 

--- a/live_server/app/__init__.py
+++ b/live_server/app/__init__.py
@@ -479,6 +479,18 @@ async def update_session_keywords_endpoint(request: Request, sid: str):
     return result
 
 
+@app.get("/api/session/{sid}/audio-usage", dependencies=[Depends(RateLimiter(times=60, seconds=60, identifier=_get_session_uid))])
+async def get_session_audio_usage_endpoint(request: Request, sid: str):
+    """Return audio buffer usage stats for the active scribe session."""
+    sid = sanitize_query_param(sid, "session ID")
+    await _verify_session_admin(request, sid)
+
+    manager = active_scribe_managers.get(sid)
+    if not manager:
+        return {"audio_bytes": 0, "audio_chunks": 0, "audio_duration_secs": 0.0, "session_elapsed_secs": 0.0}
+    return manager.get_usage_stats()
+
+
 async def get_youtube_start_time(video_id: str) -> float | None:
     """
     Get the actual stream start time for a YouTube video using YouTube Data API v3.

--- a/live_server/app/scribe_manager.py
+++ b/live_server/app/scribe_manager.py
@@ -33,6 +33,13 @@ class ScribeSessionManager:
         self.last_partial_text = ""
         self.task_group = None
         self.partial_interval = REALTIME_SETTINGS.get('PARTIAL_INTERVAL', 2)
+        # Usage tracking
+        self.audio_bytes_total = 0
+        self.audio_chunks = 0
+        self._logged_at_bytes = 0
+        # 16kHz 16-bit mono PCM: 32000 bytes per second
+        self._BYTES_PER_SEC = 16000 * 2
+        self._LOG_INTERVAL_BYTES = 30 * self._BYTES_PER_SEC  # log every 30s of audio
 
     async def get_token(self) -> str | None:
         """Get a single-use token for realtime transcription"""
@@ -50,9 +57,34 @@ class ScribeSessionManager:
             log_exception(logger, e, "Error getting Scribe API token")
             return None
 
+    def get_usage_stats(self) -> dict:
+        """Return audio usage counters for this session."""
+        duration_secs = self.audio_bytes_total / self._BYTES_PER_SEC
+        elapsed_secs = (datetime.now(timezone.utc) - self.init_time).total_seconds()
+        return {
+            "audio_bytes": self.audio_bytes_total,
+            "audio_chunks": self.audio_chunks,
+            "audio_duration_secs": round(duration_secs, 1),
+            "session_elapsed_secs": round(elapsed_secs, 1),
+        }
+
     async def push_audio(self, base64_audio: str):
         """Called by socket.io to push audio from the client"""
         if self.is_running:
+            # base64: 4 chars encode 3 bytes
+            decoded_bytes = len(base64_audio) * 3 // 4
+            self.audio_bytes_total += decoded_bytes
+            self.audio_chunks += 1
+            # Periodic usage logging
+            if self.audio_bytes_total - self._logged_at_bytes >= self._LOG_INTERVAL_BYTES:
+                self._logged_at_bytes = self.audio_bytes_total
+                duration_secs = self.audio_bytes_total / self._BYTES_PER_SEC
+                logger.info(
+                    f"[audio_usage] session={self.session_id} "
+                    f"bytes={self.audio_bytes_total} "
+                    f"duration={duration_secs:.1f}s "
+                    f"chunks={self.audio_chunks}"
+                )
             await self.audio_queue.put(base64_audio)
 
     async def send_audio_loop(self):

--- a/live_server/app/scribe_manager.py
+++ b/live_server/app/scribe_manager.py
@@ -15,6 +15,9 @@ from .logger_config import setup_logger, log_exception
 logger = setup_logger(__name__)
 
 class ScribeSessionManager:
+    _BYTES_PER_SEC = 16000 * 2          # 16kHz 16-bit mono PCM
+    _LOG_INTERVAL_BYTES = 30 * 16000 * 2  # log every 30s of audio
+
     def __init__(self, session_id, callback):
         self.session_id = session_id
         self.api_key = REALTIME_SETTINGS.get("ELEVENLABS_API_KEY", '') 
@@ -38,9 +41,6 @@ class ScribeSessionManager:
         self.audio_chunks = 0
         self._logged_at_bytes = 0
         self._usage_restored = False  # set to True after first DB restore attempt
-        # 16kHz 16-bit mono PCM: 32000 bytes per second
-        self._BYTES_PER_SEC = 16000 * 2
-        self._LOG_INTERVAL_BYTES = 30 * self._BYTES_PER_SEC  # log every 30s of audio
 
     async def get_token(self) -> str | None:
         """Get a single-use token for realtime transcription"""
@@ -66,13 +66,10 @@ class ScribeSessionManager:
 
     def get_usage_stats(self) -> dict:
         """Return audio usage counters for this session."""
-        duration_secs = self.audio_bytes_total / self._BYTES_PER_SEC
-        elapsed_secs = (datetime.now(timezone.utc) - self.init_time).total_seconds()
         return {
             "audio_bytes": self.audio_bytes_total,
             "audio_chunks": self.audio_chunks,
-            "audio_duration_secs": round(duration_secs, 1),
-            "session_elapsed_secs": round(elapsed_secs, 1),
+            "audio_duration_secs": round(self.audio_bytes_total / self._BYTES_PER_SEC, 1),
         }
 
     async def push_audio(self, base64_audio: str):

--- a/live_server/app/scribe_manager.py
+++ b/live_server/app/scribe_manager.py
@@ -37,6 +37,7 @@ class ScribeSessionManager:
         self.audio_bytes_total = 0
         self.audio_chunks = 0
         self._logged_at_bytes = 0
+        self._usage_restored = False  # set to True after first DB restore attempt
         # 16kHz 16-bit mono PCM: 32000 bytes per second
         self._BYTES_PER_SEC = 16000 * 2
         self._LOG_INTERVAL_BYTES = 30 * self._BYTES_PER_SEC  # log every 30s of audio
@@ -56,6 +57,12 @@ class ScribeSessionManager:
         except Exception as e:
             log_exception(logger, e, "Error getting Scribe API token")
             return None
+
+    def restore_usage(self, audio_bytes: int, audio_chunks: int):
+        """Restore usage counters from a previously saved DB value."""
+        self.audio_bytes_total = audio_bytes
+        self.audio_chunks = audio_chunks
+        self._logged_at_bytes = audio_bytes
 
     def get_usage_stats(self) -> dict:
         """Return audio usage counters for this session."""

--- a/live_server/app/templates/panel.html
+++ b/live_server/app/templates/panel.html
@@ -103,7 +103,8 @@
         <span id="status-text">Connecting...</span>
       </span>
       {% if is_realtime_enabled %}
-      <span id="audio-usage-display" class="text-xs text-gray-500 pr-4" title="Audio sent to transcription service this session">Audio: --</span>
+      <span id="audio-usage-display" class="text-xs text-gray-500 pr-4"
+        title="Audio sent to transcription service this session">Audio: --</span>
       {% endif %}
     </div>
 
@@ -629,103 +630,103 @@
 </script>
 <script src="/static/js/realtime.js?v={{ timestamp }}"></script>
 <script>
-  // Flow panel — shows corrected transcriptions in real-time
-  ;(function () {
-    const flowContent = document.getElementById('flow-content')
-    const flowCountEl = document.getElementById('flow-count')
-    const renderedStartTimes = new Set()
-    let partialEl = null
-    let segmentCount = 0
+    // Flow panel — shows corrected transcriptions in real-time
+    ; (function () {
+      const flowContent = document.getElementById('flow-content')
+      const flowCountEl = document.getElementById('flow-count')
+      const renderedStartTimes = new Set()
+      let partialEl = null
+      let segmentCount = 0
 
-    function updateCount() {
-      if (flowCountEl) flowCountEl.textContent = segmentCount + (segmentCount === 1 ? ' segment' : ' segments')
-    }
+      function updateCount() {
+        if (flowCountEl) flowCountEl.textContent = segmentCount + (segmentCount === 1 ? ' segment' : ' segments')
+      }
 
-    function scrollToBottom() {
-      flowContent.scrollTop = flowContent.scrollHeight
-    }
+      function scrollToBottom() {
+        flowContent.scrollTop = flowContent.scrollHeight
+      }
 
-    function appendCommitted(text) {
-      if (!text) return
-      if (partialEl) { partialEl.remove(); partialEl = null }
-      const p = document.createElement('p')
-      p.className = 'flow-item'
-      p.textContent = text
-      flowContent.appendChild(p)
-      segmentCount++
-      updateCount()
-      scrollToBottom()
-    }
-
-    function updatePartial(text) {
-      if (!text) {
+      function appendCommitted(text) {
+        if (!text) return
         if (partialEl) { partialEl.remove(); partialEl = null }
-        return
+        const p = document.createElement('p')
+        p.className = 'flow-item'
+        p.textContent = text
+        flowContent.appendChild(p)
+        segmentCount++
+        updateCount()
+        scrollToBottom()
       }
-      if (!partialEl) {
-        partialEl = document.createElement('p')
-        partialEl.className = 'flow-item-partial'
-        flowContent.appendChild(partialEl)
-      }
-      partialEl.textContent = text
-      scrollToBottom()
-    }
 
-    socket.on('transcription_update', function (data) {
-      if (data.last_committed) {
-        const lc = data.last_committed
-        if (!renderedStartTimes.has(lc.start_time)) {
-          renderedStartTimes.add(lc.start_time)
-          appendCommitted(lc.result?.corrected || lc.text || '')
+      function updatePartial(text) {
+        if (!text) {
+          if (partialEl) { partialEl.remove(); partialEl = null }
+          return
         }
-      }
-      if (data.partial) {
-        updatePartial(data.result?.corrected || data.text || '')
-      } else {
-        updatePartial(null)
-        if (!renderedStartTimes.has(data.start_time)) {
-          renderedStartTimes.add(data.start_time)
-          appendCommitted(data.result?.corrected || data.text || '')
+        if (!partialEl) {
+          partialEl = document.createElement('p')
+          partialEl.className = 'flow-item-partial'
+          flowContent.appendChild(partialEl)
         }
+        partialEl.textContent = text
+        scrollToBottom()
       }
-    })
-  })()
+
+      socket.on('transcription_update', function (data) {
+        if (data.last_committed) {
+          const lc = data.last_committed
+          if (!renderedStartTimes.has(lc.start_time)) {
+            renderedStartTimes.add(lc.start_time)
+            appendCommitted(lc.result?.corrected || lc.text || '')
+          }
+        }
+        if (data.partial) {
+          updatePartial(data.result?.corrected || data.text || '')
+        } else {
+          updatePartial(null)
+          if (!renderedStartTimes.has(data.start_time)) {
+            renderedStartTimes.add(data.start_time)
+            appendCommitted(data.result?.corrected || data.text || '')
+          }
+        }
+      })
+    })()
 </script>
 {% if is_realtime_enabled %}
 <script>
-  ;(function () {
-    const usageDisplay = document.getElementById('audio-usage-display')
-    if (!usageDisplay) return
+    ; (function () {
+      const usageDisplay = document.getElementById('audio-usage-display')
+      if (!usageDisplay) return
 
-    function formatDuration(secs) {
-      const m = Math.floor(secs / 60)
-      const s = Math.floor(secs % 60)
-      return m + ':' + String(s).padStart(2, '0')
-    }
-
-    function formatBytes(bytes) {
-      if (bytes < 1024) return bytes + ' B'
-      if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
-      return (bytes / (1024 * 1024)).toFixed(2) + ' MB'
-    }
-
-    async function fetchUsage() {
-      try {
-        const res = await fetch('/api/session/' + sid + '/audio-usage', { credentials: 'same-origin' })
-        if (!res.ok) return
-        const data = await res.json()
-        if (data.audio_bytes === 0) {
-          usageDisplay.textContent = 'Audio: --'
-        } else {
-          usageDisplay.textContent = 'Audio: ' + formatDuration(data.audio_duration_secs) + ' / ' + formatBytes(data.audio_bytes)
-        }
-      } catch (e) {
-        // Ignore fetch errors silently
+      function formatDuration(secs) {
+        const m = Math.floor(secs / 60)
+        const s = Math.floor(secs % 60)
+        return m + ':' + String(s).padStart(2, '0')
       }
-    }
 
-    setInterval(fetchUsage, 5000)
-  })()
+      function formatBytes(bytes) {
+        if (bytes < 1024) return bytes + ' B'
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
+        return (bytes / (1024 * 1024)).toFixed(2) + ' MB'
+      }
+
+      async function fetchUsage() {
+        try {
+          const res = await fetch('/api/session/' + sid + '/audio-usage', { credentials: 'same-origin' })
+          if (!res.ok) return
+          const data = await res.json()
+          if (data.audio_bytes === 0) {
+            usageDisplay.textContent = 'Audio: --'
+          } else {
+            usageDisplay.textContent = 'Audio: ' + formatDuration(data.audio_duration_secs) + ' / ' + formatBytes(data.audio_bytes)
+          }
+        } catch (e) {
+          // Ignore fetch errors silently
+        }
+      }
+
+      setInterval(fetchUsage, 5000)
+    })()
 </script>
 {% endif %}
 {% endblock %}

--- a/live_server/app/templates/panel.html
+++ b/live_server/app/templates/panel.html
@@ -97,11 +97,14 @@
         {% endif %}
       </div>
     </div>
-    <div class="flex py-1">
+    <div class="flex py-1 items-center">
       <span class="flex items-center gap-1 text-xs mx-auto">
         <span id="status-indicator" class="status-dot-md bg-gray-400"></span>
         <span id="status-text">Connecting...</span>
       </span>
+      {% if is_realtime_enabled %}
+      <span id="audio-usage-display" class="text-xs text-gray-500 pr-4" title="Audio sent to transcription service this session">Audio: --</span>
+      {% endif %}
     </div>
 
   </header>
@@ -688,4 +691,41 @@
     })
   })()
 </script>
+{% if is_realtime_enabled %}
+<script>
+  ;(function () {
+    const usageDisplay = document.getElementById('audio-usage-display')
+    if (!usageDisplay) return
+
+    function formatDuration(secs) {
+      const m = Math.floor(secs / 60)
+      const s = Math.floor(secs % 60)
+      return m + ':' + String(s).padStart(2, '0')
+    }
+
+    function formatBytes(bytes) {
+      if (bytes < 1024) return bytes + ' B'
+      if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
+      return (bytes / (1024 * 1024)).toFixed(2) + ' MB'
+    }
+
+    async function fetchUsage() {
+      try {
+        const res = await fetch('/api/session/' + sid + '/audio-usage', { credentials: 'same-origin' })
+        if (!res.ok) return
+        const data = await res.json()
+        if (data.audio_bytes === 0) {
+          usageDisplay.textContent = 'Audio: --'
+        } else {
+          usageDisplay.textContent = 'Audio: ' + formatDuration(data.audio_duration_secs) + ' / ' + formatBytes(data.audio_bytes)
+        }
+      } catch (e) {
+        // Ignore fetch errors silently
+      }
+    }
+
+    setInterval(fetchUsage, 5000)
+  })()
+</script>
+{% endif %}
 {% endblock %}

--- a/live_server/app/templates/user_dashboard.html
+++ b/live_server/app/templates/user_dashboard.html
@@ -59,16 +59,10 @@
               {% set dur = room.audio_duration_secs or 0 %}
               {% if dur > 0 %}
               <div class="flex items-center gap-2">
-                <div class="w-6 bg-gray-700 rounded h-1 flex-shrink-0">
-                  {% if max_audio_secs > 0 %}
-                  {% set pct = [(dur / max_audio_secs * 100)|int, 100]|min %}
-                  {% else %}
-                  {% set pct = 0 %}
-                  {% endif %}
-                  <div class="bg-blue-500 h-1.5 rounded" style="width: {{ pct }}%"></div>
+                <div class="w-20 bg-gray-700 rounded h-1.5 flex-shrink-0">
+                  <div class="bg-blue-500 h-1.5 rounded" style="width: {{ room.audio_pct }}%"></div>
                 </div>
-                <span class="text-xs text-gray-400 font-mono whitespace-nowrap">{{ (dur // 60)|int }}:{{ '%02d' % ((dur
-                  % 60)|int) }}</span>
+                <span class="text-xs text-gray-400 font-mono">{{ (dur // 60)|int }}:{{ '%02d' % ((dur % 60)|int) }}</span>
               </div>
               {% else %}
               <span class="text-xs text-gray-600">&mdash;</span>

--- a/live_server/app/templates/user_dashboard.html
+++ b/live_server/app/templates/user_dashboard.html
@@ -39,6 +39,7 @@
           <tr class="border-b border-gray-700 text-left text-xs text-gray-500 uppercase tracking-wider">
             <th class="px-4 py-3 font-semibold">Session ID</th>
             <th class="px-4 py-3 font-semibold">Created</th>
+            <th class="px-4 py-3 font-semibold">Audio</th>
             <th class="px-4 py-3 font-semibold text-right">Actions</th>
           </tr>
         </thead>
@@ -51,6 +52,24 @@
               {{ room.created_at[:19].replace('T', ' ') }} UTC
               {% else %}
               &mdash;
+              {% endif %}
+            </td>
+            <td class="px-4 py-3">
+              {% set dur = room.audio_duration_secs or 0 %}
+              {% if dur > 0 %}
+              <div class="flex items-center gap-2">
+                <div class="w-20 bg-gray-700 rounded h-1.5 flex-shrink-0">
+                  {% if max_audio_secs > 0 %}
+                  {% set pct = [(dur / max_audio_secs * 100)|int, 100]|min %}
+                  {% else %}
+                  {% set pct = 0 %}
+                  {% endif %}
+                  <div class="bg-blue-500 h-1.5 rounded" style="width: {{ pct }}%"></div>
+                </div>
+                <span class="text-xs text-gray-400 font-mono whitespace-nowrap">{{ (dur // 60)|int }}:{{ '%02d' % ((dur % 60)|int) }}</span>
+              </div>
+              {% else %}
+              <span class="text-xs text-gray-600">&mdash;</span>
               {% endif %}
             </td>
             <td class="px-4 py-3 text-right">

--- a/live_server/app/templates/user_dashboard.html
+++ b/live_server/app/templates/user_dashboard.html
@@ -59,10 +59,11 @@
               {% set dur = room.audio_duration_secs or 0 %}
               {% if dur > 0 %}
               <div class="flex items-center gap-2">
-                <div class="w-20 bg-gray-700 rounded h-1.5 flex-shrink-0">
-                  <div class="bg-blue-500 h-1.5 rounded" style="width: {{ room.audio_pct }}%"></div>
+                <div class="w-6 bg-gray-700 rounded h-1 flex-shrink-0">
+                  <div class="bg-blue-500 h-1 rounded" style="width: {{ room.audio_pct }}%"></div>
                 </div>
-                <span class="text-xs text-gray-400 font-mono">{{ (dur // 60)|int }}:{{ '%02d' % ((dur % 60)|int) }}</span>
+                <span class="text-xs text-gray-400 font-mono">{{ (dur // 60)|int }}:{{ '%02d' % ((dur % 60)|int)
+                  }}</span>
               </div>
               {% else %}
               <span class="text-xs text-gray-600">&mdash;</span>

--- a/live_server/app/templates/user_dashboard.html
+++ b/live_server/app/templates/user_dashboard.html
@@ -15,7 +15,8 @@
 
   {% if not is_realtime_enabled %}
   <div class="bg-amber-950 border-b border-amber-800 px-6 py-3 text-sm text-amber-300">
-    Your account does not have realtime transcription access. To use the microphone in a panel session, contact an administrator to enable it.
+    Your account does not have realtime transcription access. To use the microphone in a panel session, contact an
+    administrator to enable it.
   </div>
   {% endif %}
 
@@ -58,7 +59,7 @@
               {% set dur = room.audio_duration_secs or 0 %}
               {% if dur > 0 %}
               <div class="flex items-center gap-2">
-                <div class="w-20 bg-gray-700 rounded h-1.5 flex-shrink-0">
+                <div class="w-6 bg-gray-700 rounded h-1 flex-shrink-0">
                   {% if max_audio_secs > 0 %}
                   {% set pct = [(dur / max_audio_secs * 100)|int, 100]|min %}
                   {% else %}
@@ -66,7 +67,8 @@
                   {% endif %}
                   <div class="bg-blue-500 h-1.5 rounded" style="width: {{ pct }}%"></div>
                 </div>
-                <span class="text-xs text-gray-400 font-mono whitespace-nowrap">{{ (dur // 60)|int }}:{{ '%02d' % ((dur % 60)|int) }}</span>
+                <span class="text-xs text-gray-400 font-mono whitespace-nowrap">{{ (dur // 60)|int }}:{{ '%02d' % ((dur
+                  % 60)|int) }}</span>
               </div>
               {% else %}
               <span class="text-xs text-gray-600">&mdash;</span>


### PR DESCRIPTION
## Summary

- Add per-session audio usage tracking (bytes sent, duration, chunk count) to the live transcription panel
- Persist usage to MongoDB and display a bar graph in My Sessions
- Restore usage counters across page refreshes so totals are never lost

## What changed

**`scribe_manager.py`**

- Added `audio_bytes_total`, `audio_chunks`, and `_logged_at_bytes` counters to `ScribeSessionManager`
- `push_audio()` accumulates decoded byte count (`len(base64) * 3 // 4`) and chunk count per chunk, and logs a summary every 30 seconds of audio to the server log
- `get_usage_stats()` returns `audio_bytes`, `audio_chunks`, and `audio_duration_secs`
- `restore_usage()` resets counters from a previously saved DB value, used on page refresh
- `_BYTES_PER_SEC` and `_LOG_INTERVAL_BYTES` are class-level constants (16kHz 16-bit mono PCM)

**`__init__.py`**

- `audio_buffer_append`: on the first audio chunk of a new manager instance, loads previously saved `audio_bytes`/`audio_chunks` from `rooms_collection` and calls `restore_usage()`. The `_usage_restored` flag is set before the `await` to prevent concurrent double-restore.
- `heartbeat`: audio usage stats (`audio_bytes`, `audio_duration_secs`, `audio_chunks`) are written to `rooms_collection` in the same `update_one` call as the existing heartbeat fields, so they are saved every 10 seconds with no additional DB round-trip.
- Added `GET /api/session/{sid}/audio-usage` endpoint (admin-only, rate-limited) that reads live stats from the active scribe manager.
- `user_dashboard` route: includes `audio_bytes` and `audio_duration_secs` in the rooms projection and computes `audio_pct` (0-100) per room for proportional bar scaling.

**`panel.html`**

- Added `<span id="audio-usage-display">` in the status bar row, shown only when realtime is enabled
- A polling script fetches `/api/session/{sid}/audio-usage` every 5 seconds and renders `M:SS / X.XX MB`

**`user_dashboard.html`**

- Added an Audio column to the sessions table with an inline horizontal bar (width proportional to the session with the most audio) and an `M:SS` duration label

## Implementation notes

- Saving is piggybacked on the existing heartbeat (every 10 s) rather than on an audio-chunk interval, which avoids a separate save mechanism and ensures the final usage state is written even after recording stops
- The restore on first audio chunk means totals survive page refreshes without any user-visible gap
- `audio_pct` is computed in Python before template rendering to keep Jinja logic simple

## Test plan

- Open a panel session, enable the microphone, and verify the `Audio: M:SS / X MB` display updates every 5 seconds in the status bar
- Refresh the panel page mid-session and verify the audio counter resumes from the saved total rather than resetting to zero
- Open My Sessions and verify the Audio column shows a bar and duration for sessions where audio was recorded
- Confirm the bar widths are proportional (the session with the most audio fills the bar completely)

Generated with [Claude Code](https://claude.com/claude-code)