### PR TITLE
chore: log dev mode OTP when SMTP is unavailable

### DIFF
--- a/live_server/app/email_auth.py
+++ b/live_server/app/email_auth.py
@@ -4,6 +4,7 @@
 # See LICENSE for details.
 
 import re
+import os
 import secrets
 from datetime import datetime, timezone
 
@@ -12,6 +13,8 @@ from pymongo import ReturnDocument
 from .logger_config import setup_logger
 
 logger = setup_logger(__name__)
+
+_IS_DEVELOPMENT = os.environ.get("ENVIRONMENT", "development").lower() == "development"
 
 _EMAIL_RE = re.compile(r'^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$')
 
@@ -157,8 +160,9 @@ def _build_otp_email_html(otp: str) -> str:
 
 async def send_otp_email(email: str, otp: str, email_settings: dict) -> None:
     smtp_host = email_settings.get("SMTP_HOST", "")
-    if not smtp_host:
+    if _IS_DEVELOPMENT and not smtp_host:
         logger.info("[DEV MODE] OTP generated email=%s smtp_configured=false", _mask_email(email))
+        logger.info("[DEV MODE] OTP: %s", otp)
         return
 
     import aiosmtplib


### PR DESCRIPTION
調整 OTP email 發送流程，讓開發環境在未設定 SMTP 時可以直接從 log 取得登入驗證碼

## Changes

- 在 `email_auth.py` 加入 `ENVIRONMENT` 判斷，預設視為 `development`。
- 僅在開發環境且未設定 `SMTP_HOST` 時略過 SMTP 寄信流程。
- 開發模式下記錄遮罩後的 email 與產生的 OTP，方便本機登入測試。

<img width="1088" height="82" alt="1781775321805" src="https://github.com/user-attachments/assets/13f64210-bea8-49eb-9dbd-b219304ba4c2" />